### PR TITLE
Updated normalize.py to include skull stripping and editted dependencies in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM antsx/antspy
 
-RUN pip install nilearn statsmodels matplotlib
+RUN pip install nilearn statsmodels matplotlib antspynet
 
 # Install packages needed for fslstats
 RUN apt-get update -qq && \

--- a/src/DSCHOL-A003/normalize.py
+++ b/src/DSCHOL-A003/normalize.py
@@ -2,6 +2,7 @@ import glob
 import os
 
 import ants
+from antspynet import brain_extraction
 
 
 in_dir = '/INPUTS'
@@ -31,9 +32,16 @@ for subject in sorted(os.listdir(in_dir)):
 	orig_file = f'{subject_feobv}/mri/orig.mgz'
 	feobv_file =  f'{subject_feobv}/gtmpvc.esupravwm.output/rbv.nii.gz'
 	pib_file =  f'{subject_pib}/gtmpvc.cblmgmwm.output/rbv.nii.gz'
+	
+	# Skull Strip Original T1
+	raw = ants.image_read(orig_file)
+	extracted_mask = brain_extraction(raw, modality='t1')
+
+	#Apply mask with skull stripped
+	masked_image = ants.mask_image(raw, extracted_mask)
 
 	# Load orig T1 image as moving image for registration
-	moving = ants.image_read(orig_file)
+	moving = masked_image
 
 	# Do Registration of Moving to Fixed
 	reg = ants.registration(fixed, moving, type_of_transform='SyN')

--- a/src/DSCHOL-A003/normalize.py
+++ b/src/DSCHOL-A003/normalize.py
@@ -3,15 +3,19 @@ import os
 
 import ants
 from antspynet import brain_extraction
+from nilearn import datasets
+import nibabel as nib
 
 
 in_dir = '/INPUTS'
-atlas_file = '/REPO/atlases/mni_icbm152_t1_tal_nlin_asym_09c.nii.gz'
+atlas_ni = datasets.load_mni152_template()
 out_dir = '/OUTPUTS/DATA'
 
 
-# Load atlas as fixed target for registration
-fixed = ants.image_read(atlas_file)
+# Convert atlas_file to ants image fixed target for registration
+nib.save(atlas_ni, f'{out_dir}/atlasni.nii.gz')
+atlas=f'{out_dir}/atlasni.nii.gz'
+fixed = ants.image_read(atlas)
 
 for subject in sorted(os.listdir(in_dir)):
 	if subject.startswith('.'):


### PR DESCRIPTION
Performed skull stripping using antspynet.utilities.brain_extraction() prior to any of the warping or smoothing functions based on a T1 MRI input. Updated the docker to include antpynet. This should work on python 3.9 providing numpy<2.0.0.