### PR TITLE
Remove cerebellum from analysis

### DIFF
--- a/src/DSCHOL-A001/indiv_masks.py
+++ b/src/DSCHOL-A001/indiv_masks.py
@@ -12,6 +12,7 @@ import ants
 from nilearn import datasets
 from nilearn import masking
 from nilearn import image
+from nilearn import math_img
 
 in_dir = '/INPUTS'
 atlas_ni = datasets.load_mni152_template()
@@ -38,9 +39,18 @@ for subject in sorted(os.listdir(in_dir)):
 	mr = image.load_img(f'/OUTPUTS/DATA/{subject}/warped_orig.nii.gz')
 	resampled_mr = image.resample_to_img(mr, pet)
 	
+	#import cerebellar segmentation
+	cblm = image.load_img('/OUTPUTS/DATA/{subject}/cerebellum_mask_deep_atropos.nii.gz')
+	
+	#invert
+	inverted_cblm = math_img('1 - img', img=cblm)
 	
 	#apply nilearn mask
-	individual_mask = masking.compute_brain_mask(resampled_mr, mask_type='gm')
+	gm_mask = masking.compute_brain_mask(resampled_mr, mask_type='gm')
+	
+	#combine masks
+	
+	individual_mask = math_img('img1 * img 2)', img1=gm_mask, img2=inverted_cblm)
 	
 	#output nilearn mask for specific subject for input into study specific mask
 	#script

--- a/src/DSCHOL-A001/normalize.py
+++ b/src/DSCHOL-A001/normalize.py
@@ -1,6 +1,6 @@
 import glob
 import os
-
+import antspynet
 import ants
 from antspynet import brain_extraction
 from nilearn import datasets
@@ -17,6 +17,8 @@ os.makedirs(out_dir)
 nib.save(atlas_ni, f'{out_dir}/atlasni.nii.gz')
 atlas=f'{out_dir}/atlasni.nii.gz'
 fixed = ants.image_read(atlas)
+#set cerebellum label
+cerebellum_label = 6
 
 for subject in sorted(os.listdir(in_dir)):
 	if subject.startswith('.'):
@@ -66,3 +68,20 @@ for subject in sorted(os.listdir(in_dir)):
 	smoothed_warped_feobv_file = f'{subject_out}/smoothed_warped_FEOBV.nii.gz'
 	smoothed_feobv = ants.smooth_image(warped_feobv, 3)
 	ants.image_write(smoothed_feobv, smoothed_warped_feobv_file)
+	
+	#segment cerebellum
+	mri_mni = ants.image_read(warped_orig_file)
+	segmentation = antspynet.deep_atropos(mri_mni, do_preprocessing=False)
+	cerebellum_mask_data = (segmentation['segmentation_image'].numpy() == cerebellum_label).astype(int)
+	
+	
+	# Re-create the cerebellum mask image with correct spatial metadata
+	cerebellum_mask = ants.from_numpy(
+		cerebellum_mask_data,
+		origin=segmentation['segmentation_image'].origin,
+		spacing=segmentation['segmentation_image'].spacing,
+		direction=segmentation['segmentation_image'].direction
+	)
+	
+	# Save the cerebellum mask
+	cerebellum_mask.to_filename(f'{out_dir}/cerebellum_mask_deep_atropos.nii.gz')


### PR DESCRIPTION
Use Antspynet deep aptros to segment cerebellum in normalize, in indiv_masks.py invert the mask and combine with the GM mask.